### PR TITLE
fix #18 PlantUMLのコード上に図が1つしかないとき、図のindexを図名に含めないようにする

### DIFF
--- a/src/main/kotlin/com/change_vision/astah/plugins/converter/toastah/ToAstahActivityDiagramConverter.kt
+++ b/src/main/kotlin/com/change_vision/astah/plugins/converter/toastah/ToAstahActivityDiagramConverter.kt
@@ -16,9 +16,14 @@ object ToAstahActivityDiagramConverter {
     private val api = AstahAPI.getAstahAPI()
     private val projectAccessor = api.projectAccessor
     private val diagramEditor = projectAccessor.diagramEditorFactory.activityDiagramEditor
-    fun convert(diagram: ActivityDiagram, reader: SourceStringReader, index: Int) {
+    fun convert(
+        diagram: ActivityDiagram,
+            reader: SourceStringReader,
+            index: Int,
+            isMultiDiagrams: Boolean
+    ) {
         // create diagram
-        val astahDiagram = createOrGetDiagram(index, DiagramKind.ActivityDiagram)
+        val astahDiagram = createOrGetDiagram(index, DiagramKind.ActivityDiagram, isMultiDiagrams)
         val posMap = SVGEntityCollector.collectSvgPosition(reader, index)
 
         TransactionManager.beginTransaction()

--- a/src/main/kotlin/com/change_vision/astah/plugins/converter/toastah/ToAstahCommon.kt
+++ b/src/main/kotlin/com/change_vision/astah/plugins/converter/toastah/ToAstahCommon.kt
@@ -16,7 +16,7 @@ enum class DiagramKind {
     ClassDiagram, SequenceDiagram, StateDiagram, ActivityDiagram, UseCaseDiagram
 }
 
-fun createOrGetDiagram(index: Int, diagramType: DiagramKind) : IDiagram?{
+fun createOrGetDiagram(index: Int, diagramType: DiagramKind, isMultiDiagrams: Boolean) : IDiagram?{
     val api = AstahAPI.getAstahAPI()
     val projectAccessor = api.projectAccessor
     val diagramEditorFactory = projectAccessor.diagramEditorFactory
@@ -30,10 +30,11 @@ fun createOrGetDiagram(index: Int, diagramType: DiagramKind) : IDiagram?{
 
     val diagramsCache = getDiagramForType(diagramType, projectAccessor).associateBy { it.name }
 
+    val indexPart = if (isMultiDiagrams) "_${index}" else ""
     var diagramName = ""
 
     for (counter in 0..100) {
-        diagramName = "${diagramType.name}_${index}_${String.format("%03d",counter)}"
+        diagramName = "${diagramType.name}${indexPart}_${String.format("%03d", counter)}"
         diagramsCache[diagramName] ?: break
     }
 

--- a/src/main/kotlin/com/change_vision/astah/plugins/converter/toastah/ToAstahSequenceDiagramConverter.kt
+++ b/src/main/kotlin/com/change_vision/astah/plugins/converter/toastah/ToAstahSequenceDiagramConverter.kt
@@ -51,9 +51,9 @@ object ToAstahSequenceDiagramConverter {
     private val combinedFragmentTypes: List<String> = listOf("alt", "opt", "par", "loop",
         "critical", "neg", "assert", "strict", "ignore", "consider", "seq", "ref", "break")
 
-    fun convert(diagram: SequenceDiagram, index: Int) {
+    fun convert(diagram: SequenceDiagram, index: Int, isMultiDiagrams: Boolean) {
         // create diagram
-        val sequenceDiagram = createOrGetDiagram(index, DiagramKind.SequenceDiagram)
+        val sequenceDiagram = createOrGetDiagram(index, DiagramKind.SequenceDiagram, isMultiDiagrams)
 
         // convert lifeline
         TransactionManager.beginTransaction()

--- a/src/main/kotlin/com/change_vision/astah/plugins/converter/toastah/ToAstahStateDiagramConverter.kt
+++ b/src/main/kotlin/com/change_vision/astah/plugins/converter/toastah/ToAstahStateDiagramConverter.kt
@@ -25,9 +25,14 @@ object ToAstahStateDiagramConverter {
     private val projectAccessor = api.projectAccessor
     private val diagramEditor = projectAccessor.diagramEditorFactory.stateMachineDiagramEditor
 
-    fun convert(diagram: StateDiagram, reader: SourceStringReader, index: Int) {
+    fun convert(
+        diagram: StateDiagram,
+        reader: SourceStringReader,
+        index: Int,
+        isMultiDiagrams: Boolean
+    ) {
         // create diagram
-        val astahDiagram = createOrGetDiagram(index, DiagramKind.StateDiagram)
+        val astahDiagram = createOrGetDiagram(index, DiagramKind.StateDiagram, isMultiDiagrams)
         val posMap = SVGEntityCollector.collectSvgPosition(reader, index)
 
         TransactionManager.beginTransaction()

--- a/src/main/kotlin/com/change_vision/astah/plugins/converter/toastah/ToAstahUseCaseDiagramConverter.kt
+++ b/src/main/kotlin/com/change_vision/astah/plugins/converter/toastah/ToAstahUseCaseDiagramConverter.kt
@@ -28,7 +28,13 @@ object ToAstahUseCaseDiagramConverter {
     private val modelEditor = projectAccessor.modelEditorFactory.useCaseModelEditor
     private val basicModelEditor = projectAccessor.modelEditorFactory.basicModelEditor
 
-    fun convert(diagram: DescriptionDiagram, reader: SourceStringReader, index: Int, stereotypeMapping: Map<String, List<String>>) {
+    fun convert(
+        diagram: DescriptionDiagram,
+        reader: SourceStringReader,
+        index: Int,
+        stereotypeMapping: Map<String, List<String>>,
+        isMultiDiagrams: Boolean
+    ) {
         // 作成予定の図と同名の図を探して削除する(繰り返し実行する場合は図を削除して作り直す)
         projectAccessor.findElements(IUseCaseDiagram::class.java, "UseCaseDiagram_$index").let {
             if (it.isNotEmpty()) {
@@ -49,7 +55,7 @@ object ToAstahUseCaseDiagramConverter {
         val entityMap = successfulResults.associate { it.convertPair }
 
         // ユースケース図の作成
-        val astahDiagram = createOrGetDiagram(index, DiagramKind.UseCaseDiagram)
+        val astahDiagram = createOrGetDiagram(index, DiagramKind.UseCaseDiagram, isMultiDiagrams)
         // PlantUML 上での各図要素の位置と大きさを取得
         val posMap = SVGEntityCollector.collectSvgPosition(reader, index)
 

--- a/src/main/kotlin/com/change_vision/astah/plugins/converter/toastah/classstructure/ToAstahClassDiagramConverter.kt
+++ b/src/main/kotlin/com/change_vision/astah/plugins/converter/toastah/classstructure/ToAstahClassDiagramConverter.kt
@@ -40,7 +40,14 @@ object ToAstahClassDiagramConverter {
      * @param index 図のインデックス
      * @param stereotypeMapping クラス名とステレオタイプのマッピング
      */
-    fun convert(diagram: ClassDiagram, reader: SourceStringReader, index: Int, stereotypeMapping: Map<String, List<String>>, rawSource: String) {
+    fun convert(
+        diagram: ClassDiagram,
+        reader: SourceStringReader,
+        index: Int,
+        stereotypeMapping: Map<String, List<String>>,
+        rawSource: String,
+        isMultiDiagrams: Boolean
+    ) {
         
         // モデル要素の変換
         val leafConvertResults = createAstahModelElements(diagram.leafs(), stereotypeMapping)
@@ -62,7 +69,7 @@ object ToAstahClassDiagramConverter {
             .associate { it.convertPair }
 
         // 図の作成
-        val classDiagram = createOrGetDiagram(index, DiagramKind.ClassDiagram)
+        val classDiagram = createOrGetDiagram(index, DiagramKind.ClassDiagram, isMultiDiagrams)
         
         // 表示要素の変換
         val positionMap = SVGEntityCollector.collectSvgPosition(reader, index)

--- a/src/main/kotlin/com/change_vision/astah/plugins/converter/toastah/classstructure/ToAstahConverter.kt
+++ b/src/main/kotlin/com/change_vision/astah/plugins/converter/toastah/classstructure/ToAstahConverter.kt
@@ -55,19 +55,22 @@ object ToAstahConverter {
         val stereotypeMapping = StereotypeExtractor.extract(processedText).getOrNull() ?: emptyMap()
 
         val reader = SourceStringReader(processedText)
-        reader.blocks.map { it.diagram }.forEachIndexed { index, diagram ->
+
+        val diagramMap = reader.blocks.map { it.diagram }
+        val isMultiDiagrams = diagramMap.size != 1
+        diagramMap.forEachIndexed { index, diagram ->
             when (diagram) {
                 is ClassDiagram -> {
-                    ToAstahClassDiagramConverter.convert(diagram, reader, index, stereotypeMapping, processedText)
+                    ToAstahClassDiagramConverter.convert(diagram, reader, index, stereotypeMapping, processedText, isMultiDiagrams)
                 }
-                is SequenceDiagram -> ToAstahSequenceDiagramConverter.convert(diagram, index)
+                is SequenceDiagram -> ToAstahSequenceDiagramConverter.convert(diagram, index, isMultiDiagrams)
                 is DescriptionDiagram -> { // UseCase, Component, Deployment
                     // TODO コンポーネント図に対応する際にユースケース図かコンポーネント図かの判定も実装すること
                     // TODO 現状ではとりあえず全てユースケース図に変換するようにする(コンポーネントは無視する)
-                    ToAstahUseCaseDiagramConverter.convert(diagram, reader, index, stereotypeMapping)
+                    ToAstahUseCaseDiagramConverter.convert(diagram, reader, index, stereotypeMapping, isMultiDiagrams)
                 }
-                is StateDiagram -> ToAstahStateDiagramConverter.convert(diagram, reader, index)
-                is ActivityDiagram -> ToAstahActivityDiagramConverter.convert(diagram, reader, index)
+                is StateDiagram -> ToAstahStateDiagramConverter.convert(diagram, reader, index, isMultiDiagrams)
+                is ActivityDiagram -> ToAstahActivityDiagramConverter.convert(diagram, reader, index, isMultiDiagrams)
                 is PSystemError -> throw IllegalArgumentException(diagram.description.toString())
                 is MindMapDiagram -> throw IllegalArgumentException("unsupported diagram type")
                 else -> throw IllegalArgumentException("unknown diagram type")


### PR DESCRIPTION
fix #18 